### PR TITLE
Fix `Semigroup.lua/concatArray` failing at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Fixed `Semigroup.append` broken for `Array` (#4 by @Renegatto)
 
 Other improvements:
 

--- a/src/Data/Semigroup.lua
+++ b/src/Data/Semigroup.lua
@@ -4,7 +4,15 @@ return {
     return function(ys)
       if #xs == 0 then return ys end
       if #ys == 0 then return xs end
-      return table.concat(xs, ys)
+      local result = {}
+      for index, value in ipairs(xs) do
+        result[index] = value
+      end
+      local offset = #result
+      for index, value in ipairs(ys) do
+        result[index + offset] = value
+      end
+      return result
     end
   end)
 }


### PR DESCRIPTION
**Description of the change**

`table.concat: ([String], String, Int, Int) -> String`

Have not concatenated arrays, it is rather some equivalent of Array.prototype.join in JS.
The PR implements proper arrays concatenation instead.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
