### PR TITLE
fix: Lua 5.1 compatibility in FFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: purescript-contrib/setup-purescript@main
+      - uses: cachix/install-nix-action@v27
         with:
-          purescript: "unstable"
+          extra_nix_config: |
+            accept-flake-config = true
+            extra-substituters = https://cache.iog.io https://purescript-lua.cachix.org
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= purescript-lua.cachix.org-1:yLs4ei2HtnuPtzLekOrW3xdfm95+Etw15gwgyIGTayA=
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
+      - name: Build
+        run: nix develop -c ./scripts/build
 
-      - name: Install dependencies
-        run: |
-          npm install -g bower
-          npm install
-          bower install --production
-
-      - name: Build source
-        run: npm run-script build
-
-      - name: Run tests
-        run: |
-          bower install
-          npm run-script test --if-present
+      - name: Luacheck
+        run: nix develop -c luacheck --quiet --std min src/

--- a/src/Data/Bounded.lua
+++ b/src/Data/Bounded.lua
@@ -1,8 +1,14 @@
+-- Lua 5.1 compatibility:
+-- * math.maxinteger/math.mininteger appeared in Lua 5.3; PureScript Int
+--   is a 32-bit integer, so its bounds are spelled out literally.
+-- * "\u{...}" escapes appeared in Lua 5.3 (PUC Lua 5.1 silently reads
+--   "\u" as "u"). A Char is a single byte in pslua, so its bounds are
+--   the byte bounds.
 return {
-  topInt = (math.maxinteger),
-  bottomInt = (math.mininteger),
-  topChar = ("\u{FFFF}"),
-  bottomChar = ("\u{0000}"),
+  topInt = (2147483647),
+  bottomInt = (-2147483648),
+  topChar = ("\255"),
+  bottomChar = ("\0"),
   topNumber = (1 / 0),
   bottomNumber = (-1 / 0)
 }

--- a/src/Data/EuclideanRing.lua
+++ b/src/Data/EuclideanRing.lua
@@ -1,5 +1,6 @@
 return {
-  intDegree = (function(x) return math.min(math.abs(x), math.maxinteger) end),
+  -- math.maxinteger is Lua 5.3+; PureScript Int is 32-bit
+  intDegree = (function(x) return math.min(math.abs(x), 2147483647) end),
   intDiv = (function(x)
     return function(y)
       if y == 0 then return 0 end

--- a/src/Data/Show.lua
+++ b/src/Data/Show.lua
@@ -4,14 +4,14 @@ return {
   showCharImpl = (function(n)
     local code = n:byte()
     if code < 0x20 or code == 0x7F then
-      if n == "\x07" then return "'\\a'" end
+      if n == "\a" then return "'\\a'" end
       if n == "\b" then return "'\\b'" end
       if n == "\f" then return "'\\f'" end
       if n == "\n" then return "'\\n'" end
       if n == "\r" then return "'\\r'" end
       if n == "\t" then return "'\\t'" end
       if n == "\v" then return "'\\v'" end
-      return "'\\" .. code:toString(10) .. "'"
+      return "'\\" .. tostring(code) .. "'"
     end
     if n == "'" or n == "\\" then return "'\\" .. n .. "'" end
     return "'" .. n .. "'"
@@ -21,7 +21,7 @@ return {
     return function(xs)
       local l = #xs
       local ss = {}
-      for i = 1, l do ss[i] = f(xs[i - 1]) end
+      for i = 1, l do ss[i] = f(xs[i]) end
       return "[" .. table.concat(ss, ",") .. "]"
     end
   end)


### PR DESCRIPTION
# fix: Lua 5.1 compatibility in FFI

PUC Lua 5.1 has no `math.maxinteger`/`math.mininteger` (they are 5.3 additions, so both evaluate to `nil`), and it reads the 5.3 escapes `"\u{...}"` and `"\xNN"` by silently dropping the backslash: `"\u{FFFF}"` is the 7-byte string `u{FFFF}`, with no parse error to warn anyone. Several FFI files relied on both.

Consequences before this fix:

- `bottomChar`/`topChar` were `u{0000}`/`u{FFFF}`, so `toCharCode bottom == 117` and `toEnum 0 :: Maybe Char` returned `Nothing`. Anything built on `BoundedEnum Char` was broken.
- `topInt`/`bottomInt` were `nil`; `intDegree` would crash on `math.min(x, nil)` the first time `div`/`mod` degree logic ran.
- `showCharImpl` compared against `"\x07"` (really `x07`) and called `code:toString(10)`, a method call on a number, which throws.
- `showArrayImpl` read `xs[i - 1]` out of 1-based array tables, so the first shown element was always `nil`.

Int bounds are now spelled out as the 32-bit literals (PureScript `Int` is 32-bit), Char bounds are byte bounds (`"\0"`/`"\255"` — a `Char` is a single byte in pslua), the bell character uses the 5.1-supported `"\a"`, and the show fixes are the obvious ones.

Caught by the revived `purescript-lua-strings` test suite (Unisay/purescript-lua#36).
