### PR TITLE
fix: move comment out of the foreign return table

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 echo "Building..."
 

--- a/src/Data/EuclideanRing.lua
+++ b/src/Data/EuclideanRing.lua
@@ -1,5 +1,6 @@
+-- math.maxinteger is Lua 5.3+; PureScript Int is 32-bit, hence the
+-- literal bound in intDegree.
 return {
-  -- math.maxinteger is Lua 5.3+; PureScript Int is 32-bit
   intDegree = (function(x) return math.min(math.abs(x), 2147483647) end),
   intDiv = (function(x)
     return function(y)


### PR DESCRIPTION
Follow-up to #5.

The Lua 5.1 compat commit left the `math.maxinteger` note **inside** the returned table in `Data/EuclideanRing.lua`. pslua's foreign parser treats only the lines before `return` as a verbatim header and parses the rest as Lua, so a comment in the table is rejected with `unexpected '-'` and `Data.EuclideanRing` fails to link.

This slipped through CI because `scripts/build` ran each `pslua` invocation unchecked — the script exited 0 and the run went green while the linker error scrolled past in the log. `set -euo pipefail` makes a codegen failure fail the build, so this class of error can't pass silently again.

Verified locally: `nix develop -c ./scripts/build` now links `Data.EuclideanRing` and exits 0.
