### PR TITLE
chore: point pslua + package-set links at purescript-lua org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-A PureScript→Lua FFI fork in the [`purescript-lua`](https://github.com/Unisay/purescript-lua) package set. Generated code targets **Lua 5.1**.
+A PureScript→Lua FFI fork in the [`purescript-lua`](https://github.com/purescript-lua/purescript-lua) package set. Generated code targets **Lua 5.1**.
 
 ## Commands
 
@@ -34,12 +34,12 @@ A bare `function … end` or an unparenthesised expression fails to parse.
 
 ## Toolchain
 
-`flake.nix` pins everything through [`purescript-overlay`](https://github.com/thomashoneyman/purescript-overlay): purs 0.15.16 (`purs-bin.purs-0_15_16`), spago 0.21.0 (`spago-bin.spago-0_21_0`), Lua 5.1 (`lua51Packages`). The `pslua` input tracks `github:Unisay/purescript-lua`; keep `flake.lock` reasonably current, since a long-stale pslua pin won't create the `--lua-output-file` directory and CI fails.
+`flake.nix` pins everything through [`purescript-overlay`](https://github.com/thomashoneyman/purescript-overlay): purs 0.15.16 (`purs-bin.purs-0_15_16`), spago 0.21.0 (`spago-bin.spago-0_21_0`), Lua 5.1 (`lua51Packages`). The `pslua` input tracks `github:purescript-lua/purescript-lua`; keep `flake.lock` reasonably current, since a long-stale pslua pin won't create the `--lua-output-file` directory and CI fails.
 
 ## Releasing
 
-Tag-driven, with no GitHub Release or changelog entry. The full conventions live in the [package-set repo](https://github.com/Unisay/purescript-lua-package-sets/blob/master/CONTRIBUTING.md): push an annotated tag on `master`, bump this fork's `version` in the package set's `src/packages.dhall`, refresh `latest-compatible-sets.json`, and push a `psc-*` set tag.
+Tag-driven, with no GitHub Release or changelog entry. The full conventions live in the [package-set repo](https://github.com/purescript-lua/purescript-lua-package-sets/blob/master/CONTRIBUTING.md): push an annotated tag on `master`, bump this fork's `version` in the package set's `src/packages.dhall`, refresh `latest-compatible-sets.json`, and push a `psc-*` set tag.
 
 ## Decisions
 
-Cross-cutting decisions are recorded as ADRs in the [package-set repo](https://github.com/Unisay/purescript-lua-package-sets/tree/master/docs/adr). Read them before a decision that affects the set, and add one after making such a decision.
+Cross-cutting decisions are recorded as ADRs in the [package-set repo](https://github.com/purescript-lua/purescript-lua-package-sets/tree/master/docs/adr). Read them before a decision that affects the set, and add one after making such a decision.

--- a/flake.lock
+++ b/flake.lock
@@ -703,13 +703,13 @@
       "locked": {
         "lastModified": 1781449244,
         "narHash": "sha256-evfLWZ+i55b0cSfd/jgU5mXuBg2KDEP5WhEj2iuzIiM=",
-        "owner": "Unisay",
+        "owner": "purescript-lua",
         "repo": "purescript-lua",
         "rev": "94c13cecd1146494de56196a7badb3b1374d364d",
         "type": "github"
       },
       "original": {
-        "owner": "Unisay",
+        "owner": "purescript-lua",
         "repo": "purescript-lua",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       url = "github:thomashoneyman/purescript-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    pslua.url = "github:Unisay/purescript-lua";
+    pslua.url = "github:purescript-lua/purescript-lua";
   };
 
   outputs = { self, nixpkgs, flake-utils, purescript-overlay, pslua }:

--- a/packages.dhall
+++ b/packages.dhall
@@ -3,7 +3,7 @@ let upstream-ps =
         sha256:ae8a25645e81ff979beb397a21e5d272fae7c9ebdb021a96b1b431388c8f3c34
 
 let upstream-lua =
-      https://github.com/Unisay/purescript-lua-package-sets/releases/download/psc-0.15.15-20240416/packages.dhall
+      https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20240416/packages.dhall
         sha256:e68b7752ca4dee0f0578a2e40159caf6d1290a711777931b20d10d807823b52d
 
 in  upstream-ps // upstream-lua


### PR DESCRIPTION
The ecosystem repos moved from `Unisay/*` to the `purescript-lua` org. This updates the `pslua` flake input and its lockfile owner (same rev, 94c13ce) plus the AGENTS.md links so nothing relies on the old-owner redirect.